### PR TITLE
Added -o option

### DIFF
--- a/filelist
+++ b/filelist
@@ -118,7 +118,7 @@ function _main() {
         (IFS=$'\n'; echo "${results[*]}")
         }
     } || {
-        [ "${IS_OUTPUT_FILE}" ] && {
+        ${IS_OUTPUT_FILE} && {
             (IFS="${DELIMITER}"; echo "${results[*]}" >>$OUTPUT)
         } || {
         (IFS="${DELIMITER}"; echo "${results[*]}")

--- a/filelist
+++ b/filelist
@@ -3,11 +3,7 @@
 SCRIPT_FILE_NAME=$(basename $0)
 SCRIPT_NAME=${SCRIPT_FILE_NAME%.*}
 SELF=$(cd $(dirname $0); pwd)
-
-VERSION="0.8.0"
-
 VERSION="1.1.5"
-
 LOGGING=false
 SEPARATER='---------------------------'
 
@@ -23,7 +19,6 @@ function _usage() {
     echo "      --dotfile                  Also outputs a dot file."
     echo "  -a                             Output with absolute path."
     echo "  -c                             Show the number of files."
-
     echo "      --verbose                  Print various logging information"
     echo "  -o, --output val               List file in the specified file."
     echo
@@ -60,16 +55,14 @@ DIR=''
 EXT=()
 IS_ABSOLUTE_PATH=false
 IS_SHOW_DOT_FILE=false
-
+DELIMITER='\n'
+IS_COUNT=false
 IS_OUTPUT_FILE=false
 OUTPUT=""
 
-DELIMITER='\n'
-IS_COUNT=false
-
 
 function _main() {
-
+    local results=()
     while read -r file; do
 
         local is_print_ok=true
@@ -77,63 +70,59 @@ function _main() {
 
         file=$(echo ${file} | sed 's:^\./::')
         
-
-
-        if [ ${file:0:1} == '.' ]; then
-
         #local filename=$(echo ${file} | rev | cut -d '/' -f 1 | rev)
         local filename=$(basename ${file})
         if [ ${filename:0:1} == '.' ]; then
-
             ${IS_SHOW_DOT_FILE} || {
                 continue
             }
         fi
 
         [ ! -z ${EXT} ] && {
-            is_print_ok=false
-            for e in ${EXT[@]}; do
-                if [ "${e}" = "${file##*.}" ]; then
-                   is_print_ok=true
-                   break
-                fi
-            done
-
-            if [[ -n $OUTPUT ]]; then
+            if [[ " ${EXT[@]} " =~ " ${file##*.} " ]]; then       
                 is_print_ok=true
+            else
+                is_print_ok=false
             fi
         }
 
-        ${is_print_ok} &&  {
+        if [[ -n $OUTPUT ]]; then
+            is_print_ok=true
+        fi
+
+        ${is_print_ok} && {
             ${IS_ABSOLUTE_PATH} && {
-                ${IS_OUTPUT_FILE} && {
-                    echo "${SELF}/${file}" >>$OUTPUT
-                } || {
-                        echo "${SELF}/${file}" 
-                    }
-            } || { 
-                ${IS_OUTPUT_FILE} && {
-                echo "${file}" >>$OUTPUT
-                } || {
-                    echo "${file}"
-                    }
+            results+=("${SELF}/${file}")
+            } || {
+                # If you do not want the output file to be listed, uncomment this
+                : '
+                if [[ -n $OUTPUT ]]; then
+                    if [ ! ${file} = $OUTPUT ]; then
+                        results+=("${file}")
+                    fi
+                else
+                    results+=("${file}")
+                fi
+                '
+                results+=("${file}") # delete this line after uncommenting
             }
-
-    } 
-    done < <(find ${DIR} -type f -mindepth 1 -maxdepth 1) 
-    if [[ -s $OUTPUT ]];then
-        sed -i "/$OUTPUT/d" $OUTPUT
-    fi
-
         }
-    done < <(find "${DIR}" -type f -mindepth 1 -maxdepth 1)
+    done < <(find ${DIR} -type f -mindepth 1 -maxdepth 1) 
 
     ${IS_COUNT} && echo ${#results[@]} && exit 0
 
     [ "${DELIMITER}" = '\n' ] && {
+         ${IS_OUTPUT_FILE} && {
+            (IFS=$'\n'; echo "${results[*]}" >>$OUTPUT)
+        } || {
         (IFS=$'\n'; echo "${results[*]}")
+        }
     } || {
+        [ "${IS_OUTPUT_FILE}" ] && {
+            (IFS="${DELIMITER}"; echo "${results[*]}" >>$OUTPUT)
+        } || {
         (IFS="${DELIMITER}"; echo "${results[*]}")
+        }   
     }
 
 }
@@ -165,6 +154,14 @@ function _analyse_args_and_options() {
                     _err "-e option requires a value."
                 fi
                 EXT+=($2)
+                shift 2
+                ;;
+            # Must have argument
+            -d | --delimiter)
+                if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
+                    _err "-d option requires a value."
+                fi
+                DELIMITER=$2
                 shift 2
                 ;;
             -o | --output)                  

--- a/filelist
+++ b/filelist
@@ -3,24 +3,22 @@
 SCRIPT_FILE_NAME=$(basename $0)
 SCRIPT_NAME=${SCRIPT_FILE_NAME%.*}
 SELF=$(cd $(dirname $0); pwd)
-VERSION="1.1.0"
+VERSION="0.8.0"
 LOGGING=false
 SEPARATER='---------------------------'
 
 function _usage() {
-    echo "Usage: ${SCRIPT_NAME} [OPTIONS] [DIR PATH]"
-    echo "  This script outputs a list of files in the specified directory."
+    echo "Usage: ${SCRIPT_NAME} [OPTIONS] [SEED_FILE]"
+    echo "  This script is ~."
     echo
     echo "Options:"
     echo "  -h, --help                     Show help."
     echo "  -v, --version                  Show script version."
-    echo "  -e, --extension val            Limit the output file to the extension of siblings."
-    echo "  -d, --delimiter val            Delimiter at output."
-    echo "      --dotfile                  Also outputs a dot file."
-    echo "  -a                             Output with absolute path."
+    echo "  -e, --extension ARG            List file specified file extention."
+    echo "      --dotfile                  List dotfile(s)."
+    echo "  -a                             List file in absolute file path."
     echo "      --verbose                  Print various logging information"
     echo "  -o, --output ARG               List file in the specified file."
-
     echo
     exit 0
 }
@@ -46,7 +44,6 @@ function _verbose() {
     _log "EXT: ${EXT[@]}"
     _log "IS_ABSOLUTE_PATH: ${IS_ABSOLUTE_PATH}"
     _log "IS_SHOW_DOT_FILE: ${IS_SHOW_DOT_FILE}"
-    _log "DELIMITER: ${DELIMITER}"
     _log "${SEPARATER}"
 }
 
@@ -54,17 +51,10 @@ DIR=''
 EXT=()
 IS_ABSOLUTE_PATH=false
 IS_SHOW_DOT_FILE=false
-
 IS_OUTPUT_FILE=false
 OUTPUT=""
 
 function _main() {
-
-
-DELIMITER='\n'
-
-function _main() {
-    local results=()
 
     while read -r file; do
 
@@ -72,22 +62,15 @@ function _main() {
         local is_dot_file=false
 
         file=$(echo ${file} | sed 's:^\./::')
-
         
 
         if [ ${file:0:1} == '.' ]; then
-
-
-        local filename=$(echo ${file} | rev | cut -d '/' -f 1 | rev)
-        if [ ${filename:0:1} == '.' ]; then
-
             ${IS_SHOW_DOT_FILE} || {
                 continue
             }
         fi
 
         [ ! -z ${EXT} ] && {
-
             is_print_ok=false
             for e in ${EXT[@]}; do
                 if [ "${e}" = "${file##*.}" ]; then
@@ -98,18 +81,11 @@ function _main() {
 
             if [[ -n $OUTPUT ]]; then
                 is_print_ok=true
-
-            if [[ " ${EXT[@]} " =~ " ${file##*.} " ]]; then
-                is_print_ok=true
-            else
-                is_print_ok=false
-
             fi
         }
 
         ${is_print_ok} &&  {
             ${IS_ABSOLUTE_PATH} && {
-
                 ${IS_OUTPUT_FILE} && {
                     echo "${SELF}/${file}" >>$OUTPUT
                 } || {
@@ -124,21 +100,9 @@ function _main() {
             }
     } 
     done < <(find ${DIR} -type f -mindepth 1 -maxdepth 1) 
-    sed -i "/$OUTPUT/d" $OUTPUT
-
-                results+=("${SELF}/${file}")
-            } || {
-                results+=("${file}")
-            }
-        }
-    done < <(find "${DIR}" -type f -mindepth 1 -maxdepth 1)
-
-    [ "${DELIMITER}" = '\n' ] && {
-        (IFS=$'\n'; echo "${results[*]}")
-    } || {
-        (IFS="${DELIMITER}"; echo "${results[*]}")
-    }
-
+    if [[ -s $OUTPUT ]];then
+        sed -i "/$OUTPUT/d" $OUTPUT
+    fi
 }
 
 # -------------------------------------------------------------
@@ -163,38 +127,28 @@ function _analyse_args_and_options() {
                 LOGGING=true
                 shift
                 ;;
-
-            # Must have argument
-            -e | --extention)
+            -e | --extention)                  # Must have argument
                 if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
                     _err "-e option requires a value."
                 fi
                 EXT+=($2)
                 shift 2
                 ;;
-
             -o | --output)                  
                 if [[ -z "$2" ]]; then
                     _err "-o option requires a value."
                 else
                     IS_OUTPUT_FILE=true
                     OUTPUT=$2
-                    rm $OUTPUT
-                    touch $OUTPUT
+                    if [[ -s $OUTPUT ]]; then
+                        _err "The specified file already exists!"
+                    else
+                        touch $OUTPUT
+                    fi
                 fi
                 EXT+=($2)
                 shift 2
                 ;;
-
-            # Must have argument
-            -d | --delimiter)
-                if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
-                    _err "-d option requires a value."
-                fi
-                DELIMITER=$2
-                shift 2
-                ;;
-
             -- | -) # after this all args include '-xx', will treat arg value
                 shift
                 ARG_VALUES+=( "$@" )
@@ -221,10 +175,11 @@ function _analyse_args_and_options() {
 }
 
 function _set_variables() {
-    DIR=${ARG_VALUES[0]:=.}
+    DIR=${ARG_VALUES[0]}
 }
 
 function _verify_variables() {
+    [ -z ${DIR} ] && _err "You need to specify directory."
     [ ! -d ${DIR} ] && _err "No such directory."
     :
 }

--- a/filelist
+++ b/filelist
@@ -18,6 +18,8 @@ function _usage() {
     echo "      --dotfile                  List dotfile(s)."
     echo "  -a                             List file in absolute file path."
     echo "      --verbose                  Print various logging information"
+    echo "  -o, --output ARG               List file in the specified file."
+
     echo
     exit 0
 }
@@ -50,14 +52,19 @@ DIR=''
 EXT=()
 IS_ABSOLUTE_PATH=false
 IS_SHOW_DOT_FILE=false
+IS_OUTPUT_FILE=false
+OUTPUT=""
 
 function _main() {
+
     while read -r file; do
 
         local is_print_ok=true
         local is_dot_file=false
 
         file=$(echo ${file} | sed 's:^\./::')
+        
+
         if [ ${file:0:1} == '.' ]; then
             ${IS_SHOW_DOT_FILE} || {
                 continue
@@ -72,16 +79,29 @@ function _main() {
                    break
                 fi
             done
+
+            if [[ -n $OUTPUT ]]; then
+                is_print_ok=true
+            fi
         }
 
         ${is_print_ok} &&  {
             ${IS_ABSOLUTE_PATH} && {
-                echo "${SELF}/${file}"
-            } || {
-                echo "${file}"
+                ${IS_OUTPUT_FILE} && {
+                    echo "${SELF}/${file}" >>$OUTPUT
+                } || {
+                        echo "${SELF}/${file}" 
+                    }
+            } || { 
+                ${IS_OUTPUT_FILE} && {
+                echo "${file}" >>$OUTPUT
+                } || {
+                    echo "${file}"
+                    }
             }
-        }
-    done < <(find ${DIR} -type f -mindepth 1 -maxdepth 1)
+    } 
+    done < <(find ${DIR} -type f -mindepth 1 -maxdepth 1) 
+    sed -i "/$OUTPUT/d" $OUTPUT
 }
 
 # -------------------------------------------------------------
@@ -109,6 +129,18 @@ function _analyse_args_and_options() {
             -e | --extention)                  # Must have argument
                 if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
                     _err "-e option requires a value."
+                fi
+                EXT+=($2)
+                shift 2
+                ;;
+            -o | --output)                  
+                if [[ -z "$2" ]]; then
+                    _err "-o option requires a value."
+                else
+                    IS_OUTPUT_FILE=true
+                    OUTPUT=$2
+                    rm $OUTPUT
+                    touch $OUTPUT
                 fi
                 EXT+=($2)
                 shift 2


### PR DESCRIPTION
Added code to support the `-o` or `--output` option that will output the list in a file provided.
The `-o` option can be used followed by the filename which the file list needs to be outputted. 
```
 filelist .  -o temp.txt
```
The above command is a sample usage of the argument `-o` that works as per requirement.
Please review for any changes and do check for any bugs that I might have missed.
Thank you.
#1 